### PR TITLE
chore: update goreleaser-action to v7

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
         run: go test -v ./...
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           version: latest
           args: release --clean


### PR DESCRIPTION
## Summary
- Update `goreleaser/goreleaser-action` from v6 to v7 in the release workflow

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)